### PR TITLE
Paranoia reverse mode

### DIFF
--- a/encfs/MACFileIO.cpp
+++ b/encfs/MACFileIO.cpp
@@ -76,28 +76,19 @@ MACFileIO::MACFileIO(const std::shared_ptr<FileIO> &_base,
           << ", randBytes = " << cfg->config->blockMACRandBytes;
 }
 
-MACFileIO::~MACFileIO() {
-}
+MACFileIO::~MACFileIO() {}
 
-Interface MACFileIO::interface() const {
-  return MACFileIO_iface;
-}
+Interface MACFileIO::interface() const { return MACFileIO_iface; }
 
-int MACFileIO::open(int flags) {
-  return base->open(flags);
-}
+int MACFileIO::open(int flags) { return base->open(flags); }
 
 void MACFileIO::setFileName(const char *fileName) {
   base->setFileName(fileName);
 }
 
-const char *MACFileIO::getFileName() const {
-  return base->getFileName();
-}
+const char *MACFileIO::getFileName() const { return base->getFileName(); }
 
-bool MACFileIO::setIV(uint64_t iv) {
-  return base->setIV(iv);
-}
+bool MACFileIO::setIV(uint64_t iv) { return base->setIV(iv); }
 
 inline static off_t roundUpDivide(off_t numerator, int denominator) {
   // integer arithmetic always rounds down, so we can round up by adding
@@ -323,8 +314,7 @@ int MACFileIO::truncate(off_t size) {
   return res;
 }
 
-bool MACFileIO::isWritable() const {
-  return (reverse) ? false : base->isWritable();}
+bool MACFileIO::isWritable() const { return (reverse) ? false : base->isWritable();}
 
 }
 // namespace encfs

--- a/encfs/MACFileIO.cpp
+++ b/encfs/MACFileIO.cpp
@@ -52,8 +52,11 @@ namespace encfs {
 static Interface MACFileIO_iface("FileIO/MAC", 2, 1, 0);
 
 int dataBlockSize(const FSConfigPtr &cfg) {
-  return cfg->config->blockSize - cfg->config->blockMACBytes -
-         cfg->config->blockMACRandBytes;
+  if (cfg->reverseEncryption)
+    return cfg->config->blockSize;
+  else
+    return cfg->config->blockSize - cfg->config->blockMACBytes
+        - cfg->config->blockMACRandBytes;
 }
 
 MACFileIO::MACFileIO(const std::shared_ptr<FileIO> &_base,
@@ -64,7 +67,8 @@ MACFileIO::MACFileIO(const std::shared_ptr<FileIO> &_base,
       key(cfg->key),
       macBytes(cfg->config->blockMACBytes),
       randBytes(cfg->config->blockMACRandBytes),
-      warnOnly(cfg->opts->forceDecode) {
+      warnOnly(cfg->opts->forceDecode),
+      reverse(cfg->reverseEncryption) {
   rAssert(macBytes >= 0 && macBytes <= 8);
   rAssert(randBytes >= 0);
   VLOG(1) << "fs block size = " << cfg->config->blockSize
@@ -72,19 +76,28 @@ MACFileIO::MACFileIO(const std::shared_ptr<FileIO> &_base,
           << ", randBytes = " << cfg->config->blockMACRandBytes;
 }
 
-MACFileIO::~MACFileIO() {}
+MACFileIO::~MACFileIO() {
+}
 
-Interface MACFileIO::interface() const { return MACFileIO_iface; }
+Interface MACFileIO::interface() const {
+  return MACFileIO_iface;
+}
 
-int MACFileIO::open(int flags) { return base->open(flags); }
+int MACFileIO::open(int flags) {
+  return base->open(flags);
+}
 
 void MACFileIO::setFileName(const char *fileName) {
   base->setFileName(fileName);
 }
 
-const char *MACFileIO::getFileName() const { return base->getFileName(); }
+const char *MACFileIO::getFileName() const {
+  return base->getFileName();
+}
 
-bool MACFileIO::setIV(uint64_t iv) { return base->setIV(iv); }
+bool MACFileIO::setIV(uint64_t iv) {
+  return base->setIV(iv);
+}
 
 inline static off_t roundUpDivide(off_t numerator, int denominator) {
   // integer arithmetic always rounds down, so we can round up by adding
@@ -125,7 +138,7 @@ int MACFileIO::getAttr(struct stat *stbuf) const {
     // have to adjust size field..
     int headerSize = macBytes + randBytes;
     int bs = blockSize() + headerSize;
-    stbuf->st_size = locWithoutHeader(stbuf->st_size, bs, headerSize);
+    stbuf->st_size = (reverse) ? locWithHeader(stbuf->st_size, blockSize(), headerSize) : locWithoutHeader(stbuf->st_size, bs, headerSize);
   }
 
   return res;
@@ -137,78 +150,125 @@ off_t MACFileIO::getSize() const {
   int bs = blockSize() + headerSize;
 
   off_t size = base->getSize();
-  if (size > 0) size = locWithoutHeader(size, bs, headerSize);
+  if (size > 0) size = (reverse) ? locWithHeader(size, blockSize(), headerSize) : locWithoutHeader(size, bs, headerSize);
 
   return size;
 }
 
 ssize_t MACFileIO::readOneBlock(const IORequest &req) const {
-  int headerSize = macBytes + randBytes;
+  if (reverse == false) {
+    int headerSize = macBytes + randBytes;
 
-  int bs = blockSize() + headerSize;
+    int bs = blockSize() + headerSize;
 
-  MemBlock mb = MemoryPool::allocate(bs);
+    MemBlock mb = MemoryPool::allocate(bs);
 
-  IORequest tmp;
-  tmp.offset = locWithHeader(req.offset, bs, headerSize);
-  tmp.data = mb.data;
-  tmp.dataLen = headerSize + req.dataLen;
+    IORequest tmp;
+    tmp.offset = locWithHeader(req.offset, bs, headerSize);
+    tmp.data = mb.data;
+    tmp.dataLen = headerSize + req.dataLen;
 
-  // get the data from the base FileIO layer
-  ssize_t readSize = base->read(tmp);
+    // get the data from the base FileIO layer
+    ssize_t readSize = base->read(tmp);
 
-  // don't store zeros if configured for zero-block pass-through
-  bool skipBlock = true;
-  if (_allowHoles) {
-    for (int i = 0; i < readSize; ++i)
-      if (tmp.data[i] != 0) {
-        skipBlock = false;
-        break;
-      }
-  } else if (macBytes > 0)
-    skipBlock = false;
-
-  if (readSize > headerSize) {
-    if (!skipBlock) {
-      // At this point the data has been decoded.  So, compute the MAC of
-      // the block and check against the checksum stored in the header..
-      uint64_t mac =
-          cipher->MAC_64(tmp.data + macBytes, readSize - macBytes, key);
-
-      // Constant time comparision to prevent timing attacks
-      unsigned char fail = 0;
-      for (int i = 0; i < macBytes; ++i, mac >>= 8) {
-        int test = mac & 0xff;
-        int stored = tmp.data[i];
-
-        fail |= (test ^ stored);
-      }
-
-      if (fail > 0) {
-        // uh oh..
-        long blockNum = req.offset / bs;
-        RLOG(WARNING) << "MAC comparison failure in block " << blockNum;
-        if (!warnOnly) {
-          MemoryPool::release(mb);
-          throw Error(_("MAC comparison failure, refusing to read"));
+    // don't store zeros if configured for zero-block pass-through
+    bool skipBlock = true;
+    if (_allowHoles) {
+      for (int i = 0; i < readSize; ++i)
+        if (tmp.data[i] != 0) {
+          skipBlock = false;
+          break;
         }
+    } else if (macBytes > 0)
+      skipBlock = false;
+
+    if (readSize > headerSize) {
+      if (!skipBlock) {
+        // At this point the data has been decoded.  So, compute the MAC of
+        // the block and check against the checksum stored in the header..
+        uint64_t mac =
+            cipher->MAC_64(tmp.data + macBytes, readSize - macBytes, key);
+
+        // Constant time comparision to prevent timing attacks
+        unsigned char fail = 0;
+        for (int i = 0; i < macBytes; ++i, mac >>= 8) {
+          int test = mac & 0xff;
+          int stored = tmp.data[i];
+
+          fail |= (test ^ stored);
+        }
+
+        if (fail > 0) {
+          // uh oh..
+          long blockNum = req.offset / bs;
+          RLOG(WARNING) << "MAC comparison failure in block " << blockNum;
+          if (!warnOnly) {
+            MemoryPool::release(mb);
+            throw Error(_("MAC comparison failure, refusing to read"));
+          }
+        }
+      }
+
+      // now copy the data to the output buffer
+      readSize -= headerSize;
+      memcpy(req.data, tmp.data + headerSize, readSize);
+    } else {
+      VLOG(1) << "readSize " << readSize << " at offset " << req.offset;
+      if (readSize > 0) readSize = 0;
+    }
+
+    MemoryPool::release(mb);
+
+    return readSize;
+
+  } else {	  //reverse = true
+
+    if (randBytes > 0) {
+      throw Error(_("MAC rand bytes not yet implemented in reverse mode"));
+      return -1;
+    }
+
+    MemBlock mb = MemoryPool::allocate(blockSize());
+
+    IORequest tmp;
+    tmp.offset = locWithoutHeader(req.offset, blockSize(), macBytes);
+    tmp.data = mb.data + macBytes;
+    tmp.dataLen = req.dataLen - macBytes;
+
+    // get the data from the base FileIO layer
+    ssize_t readSize = base->read(tmp);
+    if (readSize == 0) {
+      MemoryPool::release(mb);
+      return 0;
+    }
+
+    if (macBytes > 0) {
+      uint64_t mac = cipher->MAC_64(tmp.data, readSize, key);
+
+      //point to the beginning to write the header
+      tmp.data = mb.data;
+
+      for (int i = 0; i < macBytes; ++i) {
+        tmp.data[i] = mac & 0xff;
+        mac >>= 8;
       }
     }
 
     // now copy the data to the output buffer
-    readSize -= headerSize;
-    memcpy(req.data, tmp.data + headerSize, readSize);
-  } else {
-    VLOG(1) << "readSize " << readSize << " at offset " << req.offset;
-    if (readSize > 0) readSize = 0;
+    memcpy(req.data, tmp.data, readSize + macBytes);
+    MemoryPool::release(mb);
+
+    return readSize + macBytes;
+
   }
-
-  MemoryPool::release(mb);
-
-  return readSize;
 }
 
 bool MACFileIO::writeOneBlock(const IORequest &req) {
+  if (reverse) {
+    throw Error(_("MAC write not implemented in reverse mode"));
+    return false;
+  }
+
   int headerSize = macBytes + randBytes;
 
   int bs = blockSize() + headerSize;
@@ -248,6 +308,11 @@ bool MACFileIO::writeOneBlock(const IORequest &req) {
 }
 
 int MACFileIO::truncate(off_t size) {
+  if (reverse) {
+    throw Error(_("MAC write not implemented in reverse mode"));
+    return -1;
+  }
+
   int headerSize = macBytes + randBytes;
   int bs = blockSize() + headerSize;
 
@@ -258,6 +323,8 @@ int MACFileIO::truncate(off_t size) {
   return res;
 }
 
-bool MACFileIO::isWritable() const { return base->isWritable(); }
+bool MACFileIO::isWritable() const {
+  return (reverse) ? false : base->isWritable();}
 
-}  // namespace encfs
+}
+// namespace encfs

--- a/encfs/MACFileIO.h
+++ b/encfs/MACFileIO.h
@@ -72,6 +72,7 @@ class MACFileIO : public BlockFileIO {
   int macBytes;
   int randBytes;
   bool warnOnly;
+  bool reverse;
 };
 
 }  // namespace encfs


### PR DESCRIPTION
Support paranoia set-up in reverse mode (read-only)

To enable paranoia set-up in reverse mode, it is necessary to:
a. Support Filename IV chaining
b. Support External IV chaining
c. Support Block MAC headers in files

The point (a) and (b) work just out of the box when the controls avoiding using them are disabled.
This pull request includes support for point (c).

The tests done are:
a. Chech Filename IV chaining
1. Mount paranoia in reverse mode: encfs --reverse /media/encfs/plaintext /media/encfs/ciphertext
2. Create two plaintext files with same filename in different folders: cd /media/encfs/plaintext
mkdir d1 d2
echo aa > d1/aa
echo aa > d2/aa
3. Check both files are encoded with different names: cd /media/encfs/ciphertext
ll -i *

Result: OK, same plaintext filenames ciphered to different filenames in different folders

b. Check External IV chaining
1. Mount paranoia in reverse mode: encfs --reverse /media/encfs/plaintext /media/encfs/ciphertext
2. Create a file: cd /media/encfs/plaintext
echo aa > aa
3. Get checksum of ciphered file: cd /media/encfs/ciphertext
sha1sum *
4. Rename plaintext file: cd /media/encfs/plaintext
mv aa bb
5. Get checksum of ciphered file: cd /media/encfs/ciphertext
sha1sum *
6. Rename plaintext file to original filename: cd /media/encfs/plaintext
mv bb aa
7. Get checksum of ciphered file: cd /media/encfs/ciphertext
sha1sum *

Result: OK, when a plaintext file is renamed, its ciphered filename and contents change. When it is renamed back to the original filename, the ciphered filename and contents are back to the original values.

c. Check MAC headers
1. Mount paranoia in reverse mode: encfs --reverse /media/encfs/plaintext /media/encfs/ciphertext
2. Create a file in the plaintext folder: cd /media/encfs/plaintext
echo aa > aa
3. Copy the ciphered file to a new folder: cd /media/encfs/ciphertext
cp * /media/encfs/copy_of_ciphertext
4. Copy the config file of step 1 to the new folder: cp /media/encfs/plaintext/.encfs6.xml /media/encfs/copy_of_ciphertext
5. Mount it in normal mode: encfs /media/encfs/copy_of_ciphertext /media/encfs/copy_of_plaintext
6. Check sha1sum of original and copied files: sha1sum /media/encfs/plaintext/aa /media/encfs/copy_of_plaintext/aa
7. Modify copied cipherfile: echo a >> /media/encfs/copy_of_ciphertext/*
8. Check sha1sum of original and copied files: sha1sum /media/encfs/plaintext/aa /media/encfs/copy_of_plaintext/aa

Result: OK, the check in step 6 matches. The check after altering the cipherfiles shows an IO error

d. Non Regression Tests
1. Mount paranoia in reverse mode: encfs --reverse /media/encfs/plaintext /media/encfs/ciphertext
2. Extract and get SHA1 checksum of linux kernel sources (example with lots of different files): cd /media/encfs/plaintext
rhash -r -H * > SHA1SUM
3. Copy ciphered files to a new folder: cd /media/encfs/copy_of_ciphertext
cp -R /media/encfs/ciphertext/* .
4. Copy the config file of step 1 to the new folder: cp /media/encfs/plaintext/.encfs6.xml /media/encfs/copy_of_ciphertext
5. Mount it in normal mode: encfs /media/encfs/copy_of_ciphertext /media/encfs/copy_of_plaintext
6. Check SHA1SUM of all copied files: cd /media/encfs/copy_of_plaintext
rhash -c SHA1SUM

Result: OK, SHA1SUM of all files is correct




